### PR TITLE
7 vote on a review

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,6 +24,7 @@ li {
 
 .reviewDetail {
   border-style: solid;
+  width: 90%;
 }
 
 img {

--- a/src/components/ReviewDetail.jsx
+++ b/src/components/ReviewDetail.jsx
@@ -5,25 +5,66 @@ import axios from "axios";
 function ReviewDetail() {
   const { review_id } = useParams();
   const [review, setReview] = useState({});
+  const date = Date(review.created_at);
+  const [err, setErr] = useState(null);
 
-  useEffect(() => {
+  function displayReview() {
     axios
       .get(`https://tr-games-api.herokuapp.com/api/reviews/${review_id}`)
       .then((res) => {
         setReview(res.data.review);
       });
+  }
+
+  useEffect(() => {
+    displayReview();
   }, []);
 
   return (
     <div className="reviewDetail">
       <h3>{review.title}</h3>
-      <h5>
-        By {review.owner} - {Date(review.created_at)}
-      </h5>
+      <h5>By {review.owner}</h5>
       <img src={review.review_img_url} alt={review.title} />
       <p>
         Votes: {review.votes} - Comments: {review.comment_count}
       </p>
+      <button
+        onClick={(e) => {
+          const upvotedReview = { ...review };
+          upvotedReview.votes = upvotedReview.votes + 1;
+          setReview(upvotedReview);
+          setErr(null);
+          axios
+            .patch(
+              `https://tr-games-api.herokuapp.com/api/reviews/${review_id}`,
+              { inc_votes: 1 }
+            )
+            .catch((err) => {
+              setReview(review);
+              setErr("Something went wrong, please try again");
+            });
+        }}
+      >
+        Upvote
+      </button>
+      <button
+        onClick={(e) => {
+          const upvotedReview = { ...review };
+          upvotedReview.votes = upvotedReview.votes - 1;
+          setReview(upvotedReview);
+          axios
+            .patch(
+              `https://tr-games-api.herokuapp.com/api/reviews/${review_id}`,
+              { inc_votes: -1 }
+            )
+            .catch((err) => {
+              setReview(review);
+              setErr("Something went wrong, please try again");
+            });
+        }}
+      >
+        Downvote
+      </button>
       <p>
         Category: {review.category}
         <br />

--- a/src/components/ReviewDetail.jsx
+++ b/src/components/ReviewDetail.jsx
@@ -5,6 +5,7 @@ import axios from "axios";
 function ReviewDetail() {
   const { review_id } = useParams();
   const [review, setReview] = useState({});
+  const [voteStatus, setVoteStatus] = useState(0);
   const date = Date(review.created_at);
   const [err, setErr] = useState(null);
 
@@ -28,8 +29,11 @@ function ReviewDetail() {
       <p>
         Votes: {review.votes} - Comments: {review.comment_count}
       </p>
+      <p>Your vote: {voteStatus}</p>
       <button
+        disabled={voteStatus}
         onClick={(e) => {
+          setVoteStatus(1);
           const upvotedReview = { ...review };
           upvotedReview.votes = upvotedReview.votes + 1;
           setReview(upvotedReview);
@@ -48,7 +52,9 @@ function ReviewDetail() {
         Upvote
       </button>
       <button
+        disabled={voteStatus}
         onClick={(e) => {
+          setVoteStatus(-1);
           const upvotedReview = { ...review };
           upvotedReview.votes = upvotedReview.votes - 1;
           setReview(upvotedReview);
@@ -64,6 +70,26 @@ function ReviewDetail() {
         }}
       >
         Downvote
+      </button>
+      <button
+        disabled={!voteStatus}
+        onClick={(e) => {
+          setVoteStatus(0);
+          const upvotedReview = { ...review };
+          upvotedReview.votes = upvotedReview.votes - voteStatus;
+          setReview(upvotedReview);
+          axios
+            .patch(
+              `https://tr-games-api.herokuapp.com/api/reviews/${review_id}`,
+              { inc_votes: -voteStatus }
+            )
+            .catch((err) => {
+              setReview(review);
+              setErr("Something went wrong, please try again");
+            });
+        }}
+      >
+        Reset
       </button>
       <p>
         Category: {review.category}


### PR DESCRIPTION
Bug: When I invoke setReview with a review object with a new votes number, it's also reassigning the created_date. I think it's a problem with the API call, the patch request is changing the data in the database for created_date when it should only change the votes number.

I've just removed the created_date from the review display for now and i'm happy to continue with new tickets and fix the API later. I could probably get around it in the front end but seems correct to fix in back end.

I'll also add the bug to the issues log.